### PR TITLE
Adding npmignore file to fix the dist folder issue in published module.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+*~
+*.iml
+.*.haste_cache.*
+.idea
+*.sublime-project
+*.sublime-workspace

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdns-ui-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "This is the open source UI library for react components using Foundation Services (FDNS).",
   "main": "dist/index.js",
   "jsnext:main": "dist/index.js",


### PR DESCRIPTION
Adds a `.npmignore` so that the `/dist` folder is not ignored in the `npm pack` command upon publishing. The files in `/dist` are critical for the package to function.