### PR TITLE
Reverting the bootstrap upgrade and fixing an issue in DataLayers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,9 +2350,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
-      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
     "boxen": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@fortawesome/react-fontawesome": "^0.1.3",
     "animate.css": "^3.7.0",
     "babel-runtime": "^6.26.0",
-    "bootstrap": "^4.1.2",
+    "bootstrap": "^3.3.7",
     "fixed-data-table-2": "^0.8.15",
     "flexbox": "0.0.3",
     "i": "^0.3.6",

--- a/src/fixtures/shapes.js
+++ b/src/fixtures/shapes.js
@@ -4,7 +4,10 @@ export const _header = PropTypes.shape({
   path: PropTypes.string,
   label: PropTypes.string,
   visible: PropTypes.bool,
-  icon: PropTypes.string,
+  icon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array
+  ]),
   iconColor: PropTypes.string,
 });
 


### PR DESCRIPTION
Downgrading Bootstrap because React-Bootstrap currently relies on V3 CSS. Fixing a proptypes issue in shapes