### PR TITLE
Adding a onDrop prop to the Uploader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fdns-ui-react",
-  "version": "0.6.2",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdns-ui-react",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "This is the open source UI library for react components using Foundation Services (FDNS).",
   "main": "dist/index.js",
   "jsnext:main": "dist/index.js",

--- a/src/components/Uploader.js
+++ b/src/components/Uploader.js
@@ -10,12 +10,14 @@ import { Grid } from '@material-ui/core';
 const propTypes = {
   checkDuplicates: PropTypes.bool,
   onError: PropTypes.func,
+  onDrop: PropTypes.func,
 };
 
 // set the defaults
 const defaultProps = {
   checkDuplicates: true,
   onError() {},
+  onDrop() {},
 };
 
 // define the class
@@ -48,6 +50,8 @@ class Uploader extends Component {
 
   // handle drop
   handleDropUpload(files) {
+    this.props.onDrop(files);
+
     let newFileNames = this.state.fileNames;
 
     // look for duplicates or just add file names


### PR DESCRIPTION
This PR adds a simple onDrop prop to the Uploader which allows the end developer to utilize the onDrop trigger from UploaderDrop which were not previously available on Uploader.